### PR TITLE
update_references before checking tags, for tags created since repo was initially created

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -30,6 +30,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
   
   def revision
+    update_references
     current   = at_path { git('rev-parse', 'HEAD') }
     canonical = at_path { git('rev-parse', @resource.value(:revision)) }
     if current == canonical


### PR DESCRIPTION
If tags are created upstream since the vcsrepo was created, and the vcsrepo instance gets these tags as its revision, the module will fail to compare git rev-parse HEAD + tag, since it does not know about those tags yet.  Use the update_references function to pull tags before comparing.
