### PR TITLE
Added autorequire

### DIFF
--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -99,4 +99,21 @@ Puppet::Type.newtype(:vcsrepo) do
     end
   end
 
+  # Autorequire the nearest ancestor directory found in the catalog.
+  # Taken from puppet/type/file in the puppet source
+  autorequire(:file) do
+    basedir = ::File.dirname(self[:path])
+    if basedir != self[:path]
+      parents = []
+      until basedir == parents.last
+        parents << basedir
+        basedir = ::File.dirname(basedir)
+      end
+      # The filename of the first ancestor found, or nil
+      parents.find { |dir| catalog.resource(:file, dir) }
+    else
+      nil
+    end
+  end
+
 end


### PR DESCRIPTION
Howdy,

I copied the 'parent directory autorequire' from puppet's file type. Now, if puppet manages the parent directories of a vcsrepo, those directories will be created before the vcsrepo is handled.

Cheers,
Pete
